### PR TITLE
updated K8s .tf detectors to use new OTel metrics and metric names

### DIFF
--- a/modules/kubernetes/cluster.tf
+++ b/modules/kubernetes/cluster.tf
@@ -3,7 +3,7 @@ resource "signalfx_detector" "k8s_cluster_cpu_capacity" {
   name         = "${var.sfx_prefix} K8S Cluster CPU Capacity approaching limit"
   description  = "Alerts when Cluster is approaching CPU capacity"
   program_text = <<-EOF
-    A = data('container_cpu_percent', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('sf_tags', '*', match_missing=True) and filter('deployment', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_cluster']).scale(0.01).publish(label='A')
+    A = data('container_cpu_percent', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('sf_tags', '*', match_missing=True) and filter('k8s.deployment.name', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_cluster']).scale(0.01).publish(label='A')
     B = data('kube_node_status_allocatable_cpu_cores', filter=filter('kubernetes_cluster', '*')).sum(by=['kubernetes_cluster']).publish(label='B')
     C = (A/B).publish(label='K8S Cluster CPU Capacity approaching limit')
   EOF
@@ -37,8 +37,8 @@ resource "signalfx_detector" "k8s_daemonset_ready_vs_scheduled" {
   name         = "${var.sfx_prefix} K8S Cluster DaemonSet ready vs scheduled"
   description  = "Alerts when number of ready and scheduled DaemonSets have diverged"
   program_text = <<-EOF
-    A = data('kube_daemonset_status_number_ready', filter=filter('kubernetes_cluster', '*') and filter('daemonset', '*')).sum(by=['kubernetes_cluster', 'daemonset']).publish(label='A', enable=False)
-    B = data('kube_daemonset_status_desired_number_scheduled', filter=filter('kubernetes_cluster', '*') and filter('daemonset', '*')).sum(by=['kubernetes_cluster', 'daemonset']).publish(label='B', enable=False)
+    A = data('k8s.daemonset.ready_nodes', filter=filter('k8s.cluster.name', '*') and filter('k8s.daemonset.name', '*')).sum(by=['k8s.cluster.name', 'k8s.daemonset.name']).publish(label='A', enable=False)
+    B = data('k8s.daemonset.desired_scheduled_nodes', filter=filter('k8s.cluster.name', '*') and filter('k8s.daemonset.name', '*')).sum(by=['k8s.cluster.name', 'k8s.daemonset.name']).publish(label='B', enable=False)
     C = (A-B).publish(label='C')
     detect((when((C > 0) or (C < 0), lasting='5m', at_least=0.95))).publish('K8S Cluster DaemonSet ready and scheduled have diverged')
   EOF
@@ -53,8 +53,8 @@ resource "signalfx_detector" "k8s_deployment_not_at_spec" {
   name         = "${var.sfx_prefix} K8S Cluster Deployment is not at spec"
   description  = "Alerts when number of ready and available pods in Deployments have diverged"
   program_text = <<-EOF
-    A = data('kubernetes.deployment.available').sum(by=['kubernetes_cluster', 'deployment', 'kubernetes_namespace']).publish(label='A', enable=False)
-    B = data('kubernetes.deployment.desired').sum(by=['kubernetes_cluster', 'deployment', 'kubernetes_namespace']).publish(label='B', enable=False)
+    A = data('k8s.deployment.available').sum(by=['k8s.cluster.name', 'k8s.deployment.name', 'k8s.namespace.name']).publish(label='A', enable=False)
+    B = data('k8s.deployment.desired').sum(by=['k8s.cluster.name', 'k8s.deployment.name', 'k8s.namespace.name']).publish(label='B', enable=False)
     C = (A-B).publish(label='C')
     detect((when((C > 0) or (C < 0), lasting='5m', at_least=0.8))).publish('K8S Cluster Deployment is not at spec')
   EOF

--- a/modules/kubernetes/container.tf
+++ b/modules/kubernetes/container.tf
@@ -2,7 +2,7 @@ resource "signalfx_detector" "k8s_container_restarts" {
   name         = "${var.sfx_prefix} K8S Container restart count is > 0"
   description  = "Container restart count in the last 5m is > 0"
   program_text = <<-EOF
-    A = data('kubernetes.container_restart_count').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_pod_name']).delta().sum(over='5m').above(0, inclusive=True, clamp=True).publish(label='A')
+    A = data('k8s.container.restarts').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']).delta().sum(over='5m').above(0, inclusive=True, clamp=True).publish(label='A')
     detect(when(A > threshold(0), lasting='5m')).publish('K8S Container restart count is > 0')
   EOF
   rule {
@@ -17,7 +17,7 @@ resource "signalfx_detector" "k8s_container_cpu" {
   description  = "Alerts when container CPU utilization (%) in the last 5m is more than 2.5 standard deviations above the mean of its preceding 30m"
   program_text = <<-EOF
     from signalfx.detectors.against_recent import against_recent
-    A = data('container_cpu_percent', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('sf_tags', '*', match_missing=True) and filter('deployment', '*', match_missing=True), rollup='rate').publish(label='A', enable=False)
+    A = data('container_cpu_percent', filter=filter('k8s.cluster.name', '*') and filter('k8s.namespace.name', '*') and filter('k8s.deployment.name', '*', match_missing=True), rollup='rate').publish(label='A', enable=False)
     against_recent.detector_mean_std(stream=A, current_window='5m', historical_window='30m', fire_num_stddev=2.5, clear_num_stddev=2, orientation='above', ignore_extremes=True, calculation_mode='vanilla').publish('K8S Container CPU Usage higher than normal, and increasing')
   EOF
   rule {
@@ -33,7 +33,7 @@ resource "signalfx_detector" "k8s_container_memory" {
   description  = "Alerts when container memory utilization of top 5 in the last 15m is more than 3.5 standard deviations above the median of similar signals for 100% of 15m"
   program_text = <<-EOF
 from signalfx.detectors.population_comparison import population
-A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*') and filter('sf_tags', '*')).sum(by=['container_name']).top(by=['kubernetes_cluster'], count=5).publish(label='A', enable=False)
+A = data('container.memory.usage', filter=filter('k8s.cluster.name', '*') and filter('k8s.namespace.name', '*') and filter('k8s.deployment.name', '*')).sum(by=['container.name']).top(by=['k8s.cluster.name'], count=5).publish(label='A', enable=False)
 D = (A).mean(over='5m').publish(label='D', enable=False)
 population.detector(population_stream=A, group_by_property=None, fire_num_dev=3.5, fire_lasting=lasting('15m', 1), clear_num_dev=3, clear_lasting=lasting('15m', 1), strategy='median_MAD', orientation='above').publish('K8S Container Memory Usage higher than normal, and increasing')
   EOF
@@ -43,4 +43,3 @@ population.detector(population_stream=A, group_by_property=None, fire_num_dev=3.
     parameterized_body = var.message_body
   }
 }
-

--- a/modules/kubernetes/node.tf
+++ b/modules/kubernetes/node.tf
@@ -3,10 +3,10 @@ resource "signalfx_detector" "k8s_node_cpu_imbalance" {
   name         = "${var.sfx_prefix} K8S Cluster CPU balance"
   description  = "Alerts when cluster CPU usage is imbalanced"
   program_text = <<-EOF
-    A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*'), rollup='rate').sum(by=['kubernetes_node', 'kubernetes_cluster']).publish(label='A', enable=False)
-    B = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_node']).mean(by=['kubernetes_cluster']).publish(label='B', enable=False)
-    C = ((A-B)/B).stddev(by=['kubernetes_cluster']).publish(label='C', enable=False)
-    D = data('kube_node_info', filter=filter('kubernetes_cluster', '*'), rollup='count').count(by=['kubernetes_cluster']).publish(label='D', enable=False)
+    A = data('container_cpu_utilization', filter=filter('k8s.cluster.name', '*') and filter('k8s.node.name', '*'), rollup='rate').sum(by=['k8s.node.name', 'k8s.cluster.name']).publish(label='A', enable=False)
+    B = data('container_cpu_utilization', filter=filter('k8s.cluster.name', '*') and filter('k8s.node.name', '*')).sum(by=['k8s.node.name']).mean(by=['k8s.cluster.name']).publish(label='B', enable=False)
+    C = ((A-B)/B).stddev(by=['k8s.cluster.name']).publish(label='C', enable=False)
+    D = data('kube_node_info', filter=filter('k8s.cluster.name', '*'), rollup='count').count(by=['k8s.cluster.name']).publish(label='D', enable=False)
     E = (C*D).publish(label='K8S Cluster CPU usage is imbalanced')
   EOF
   rule {
@@ -22,8 +22,8 @@ resource "signalfx_detector" "k8s_node_not_ready" {
   name         = "${var.sfx_prefix} K8S Nodes are not ready"
   description  = "Alerts when K8s Node is not a ready state"
   program_text = <<-EOF
-    A = data('kubernetes.node_ready').sum(by=['kubernetes_cluster', 'kubernetes_node']).publish(label='A')
-    detect(when(A < threshold(0), lasting='30s')).publish('K8s Node is not in a ready state')
+    A = data('k8s.node.condition_ready').sum(by=['k8s.cluster.name', 'k8s.node.name']).publish(label='A')
+    detect(when(A < threshold(1), lasting='30s')).publish('K8s Node is not in a ready state')
   EOF
   rule {
     detect_label = "K8s Node is not in a ready state"
@@ -37,7 +37,7 @@ resource "signalfx_detector" "k8s_node_high_memory" {
   name         = "${var.sfx_prefix} K8S Node Memory > 90%"
   description  = "Alerts when K8s Node is using memory > 90% for 5m"
   program_text = <<-EOF
-    A = data('memory.utilization', filter=filter('kubernetes_cluster', '*')).sum(by=['host', 'kubernetes_cluster']).publish(label='A')
+    A = data('memory.utilization', filter=filter('k8s.cluster.name', '*')).sum(by=['host', 'k8s.cluster.name']).publish(label='A')
     detect(when(A > threshold(90), lasting='5m')).publish('K8s Node Memory is higher than 90% for 5m')
   EOF
   rule {


### PR DESCRIPTION
Updated the sample detectors for kubernetes to use the new metric names and dimensions sent by OpenTelemetry.
Fixed a calculation error: (a+b/d)*100 -- should have been (a+b)/d*100
Submitted by Alex Pakter apakter@splunk.com